### PR TITLE
Fix code scanning alert no. 3: Stored cross-site scripting

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -21,9 +21,11 @@ export function getPostBySlug(slug: string): Post | null {
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
 
+  const window = new JSDOM('').window
+  const purify = DOMPurify(window as unknown as Window)
   return {
     ...data,
-    slug: realSlug,
+    slug: purify.sanitize(realSlug),
     content,
   } as Post
 }


### PR DESCRIPTION
Fixes [https://github.com/nsgpriyanshu/creatorsworld/security/code-scanning/3](https://github.com/nsgpriyanshu/creatorsworld/security/code-scanning/3)

To fix the problem, we need to sanitize the `slug` value before using it in the `href` attribute. This can be done using a library like `DOMPurify` to ensure that any potentially harmful content is removed. We will sanitize the `slug` value in the `getPostBySlug` function in `src/lib/posts.ts` before it is returned and used in the `BlogPage` component.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
